### PR TITLE
Documaster API: draft 9

### DIFF
--- a/v1/endpoints.md
+++ b/v1/endpoints.md
@@ -2,7 +2,7 @@
 
 This document specifies information about the Documaster API endpoints:
 - [Basic concepts](#basic-concepts)
-- [Endpoints](#endpoints)
+- [Resource Endpoints](#resource-endpoints)
   - [Fetch endpoint](#fetch-endpoint) - GET /{resource}
   - [Fetch by ID endpoint](#fetch-by-id-endpoint) - GET /{resource}/{id}
   - [Fetch related endpoint](#fetch-related-endpoint) - GET /{resource}/{id}/{related-resource}
@@ -13,6 +13,12 @@ This document specifies information about the Documaster API endpoints:
   - [Search](#search-endpoint) - POST /{resource}/search
   - [Upload](#upload-endpoint) - POST upload-temp/
   - [Download](#download-endpoint) - GET download/{id}
+- [Access Group Endpoints](#access-group-endpoints)
+  - [Fetch access groups endpoint](#fetch-access-groups-endpoint) - GET /access-group
+  - [Fetch access group by ID endpoint](#fetch-access-group-by-id-endpoint) - GET /access-group/{id}
+  - [Create access group endpoint](#create-access-group-endpoint) - POST /access-group
+  - [Update access group endpoint](#update-access-group-endpoint) - PUT /access-group
+  - [Delete access group endpoint](#delete-access-group-endpoint) - DELETE /access-group
 - [Error response format](#error-response-format)
 
 Refer to the [Model specification](model.md) for more information on the `{resource}` path parameter and the contents of `data`, `expand` and `attributes` used in this document.
@@ -65,7 +71,7 @@ All endpoints appear under the following base path:
 
 ---
 
-# Endpoints
+# Resource Endpoints
 
 ## Fetch endpoint
 
@@ -939,6 +945,213 @@ Content-type: */*
 ```
 
 See [RFC 6266](http://tools.ietf.org/html/rfc6266) (description of the Content-Disposition header) and [RFC 5987](https://tools.ietf.org/html/rfc5987#section-3.2) (description of the encoding used in the filename* parameter).
+
+---
+
+# Access Group Endpoints
+
+## Fetch access groups endpoint
+
+Retrieve the access groups, if any.
+
+### Request
+
+```
+GET /access-group?page=1&pageSize=10 HTTP/1.1
+Accept: application/json
+Authorization: Bearer {token}
+```
+
+- `page` (optional)
+  - specifies the page to fetch; 1-based
+  - defaults to 1
+- `pageSize` (optional)
+  - specifies the page size
+  - defaults to 10
+  - maximum allowed value is 1000
+
+### Response
+
+```
+200 OK
+Content-type: application/json
+
+{
+    "data": [
+        {
+            attribute: value,
+            ...
+        },
+        ...
+    ],
+    "hasMore": boolean,
+    "page": integer,
+    "pageSize": integer
+}
+```
+
+- `data`
+  - contains a (potentially empty) list of access groups
+- `hasMore`
+  - specifies whether more pages exist
+- `page`
+  - the requested page
+- `pageSize`
+  - the requested page size
+
+Response codes:
+- `200 OK`
+- `400 Bad request`
+
+---
+
+## Fetch access group by ID endpoint
+
+Retrieves the access group with the specified ID, if any.
+
+### Request
+
+```
+GET /access-group/{id} HTTP/1.1
+Accept: application/json
+Authorization: Bearer {token}
+```
+
+### Response
+
+```
+200 OK
+Content-type: application/json
+
+{
+    "data": {
+        attribute: value,
+        ...
+    }
+}
+```
+
+- `data`
+  - contains the (potentially empty) resource with the specified ID
+  - at most 10 nested resources per type will be returned; more information on retrieving additional resources can be found in `__resources`
+
+Response codes:
+- `200 OK`
+- `400 Bad request`
+- `403 Unauthorized`
+
+---
+
+## Create access group endpoint
+
+Creates a new access group.
+
+### Request
+
+```
+POST /access-group HTTP/1.1
+Accept: application/json
+Authorization: Bearer {token}
+Content-type: application/json
+
+{
+    "data": { attribute: value, ... }
+}
+```
+
+- `data`
+  - contains the access group to be created
+
+### Response
+
+```
+201 Created
+Content-type: application/json
+
+{
+    "data": {
+        attribute: value,
+        ...
+    }
+}
+```
+
+- `data`
+  - contains the created resource
+
+Response codes:
+- `201 Created`
+- `400 Bad request`
+- `403 Unauthorized`
+
+---
+
+## Update access group endpoint
+
+Updates an existing access group.
+
+### Request
+
+```
+PUT /access-group/{id} HTTP/1.1
+Accept: application/json
+Authorization: Bearer {token}
+Content-type: application/json
+
+{
+    "data": { attribute: value, ... }
+}
+```
+
+- `data` (optional)
+  - contains the access group to be updated
+  - specified attributes will **replace** the existing value
+
+### Response
+
+```
+200 OK
+Content-type: application/json
+
+{
+    "data": {
+        attribute: value,
+        ...
+    }
+}
+```
+
+- `data`
+  - contains the updated resource
+
+Response codes:
+- `200 OK`
+- `400 Bad request`
+- `403 Unauthorized`
+
+---
+
+## Delete access group endpoint
+
+Deletes the specified access group.
+
+### Request
+
+```
+DELETE /access-group/{id} HTTP/1.1
+Authorization: Bearer {token}
+```
+
+### Response
+
+```
+204 No content
+```
+
+Response codes:
+- `204 No content`
+- `400 Bad request`
+- `403 Unauthorized`
 
 ---
 

--- a/v1/model.md
+++ b/v1/model.md
@@ -21,8 +21,13 @@ You can jump right to the section you are interested in:
   - [Document](#document)
   - [DocumentVersion](#document-version)
   - [ExternalId](#external-id)
+  - [AccessGroup](#access-group)
   - [Model Constraints](#model-constraints)
   - [Highlights](#highlights)
+  - [Effective permissions](#effective-permissions)
+  - [Explicit permissions](#explicit-permissions)
+    - [Explicit permissions use cases](#explicit-permissions-use-cases)
+  - [Service permissions](#service-permissions)
 
 (!) Note that any users of the Documaster API must disregard the presense of unknown attributes, (nested) resources, or parameters in any of the endpoints or resources to allow for backwards-compatible expansions of the API.
 
@@ -98,23 +103,27 @@ The `expand` sections describe the supported values for the `expand` field in re
 
 ### Data
 
+The Classification resource is identified by `classification` in URLs.
+
 A Classification is identified by the following attributes:
 
-| Attribute       | Sort | Data type          | Comment                                                             |
-|-----------------|------|--------------------|---------------------------------------------------------------------|
-| id              | X    | string             | (Globally) Unique identifier of the resource                        |
-| revision        | X    | integer            | Revision of the resource used for concurrent modification detection |
-| createdDate     | X    | timestamp          | Timestamp at which the resource was created                         |
-| createdBy       | X    | string             | User name of the user who created the resource                      |
-| createdByUserId | X    | string             | User ID of the user who created the resource                        |
-| updatedDate     | X    | timestamp          | Timestamp at which the resource was updated                         |
-| updatedBy       | X    | string             | User name of the user who last updated the resource                 |
-| updatedByUserId | X    | string             | User ID of the user who updated the resource                        |
-| title           | X    | string             | Title of the classification                                         |
-| description     | X    | string             | Description of the Classification                                   |
-| highlights      |      | highlight snippets | [Highlight snippets](#highlights) per resource attribute.           |
-| classification  |      | array of resources | Related Tags                                                        |
-| sections        |      | array of resources | Related Sections                                                    |
+| Attribute            | Sort | Data type            | Comment                                                             |
+|----------------------|------|----------------------|---------------------------------------------------------------------|
+| id                   | X    | string               | (Globally) Unique identifier of the resource                        |
+| revision             | X    | integer              | Revision of the resource used for concurrent modification detection |
+| createdDate          | X    | timestamp            | Timestamp at which the resource was created                         |
+| createdBy            | X    | string               | User name of the user who created the resource                      |
+| createdByUserId      | X    | string               | User ID of the user who created the resource                        |
+| updatedDate          | X    | timestamp            | Timestamp at which the resource was updated                         |
+| updatedBy            | X    | string               | User name of the user who last updated the resource                 |
+| updatedByUserId      | X    | string               | User ID of the user who updated the resource                        |
+| title                | X    | string               | Title of the classification                                         |
+| description          | X    | string               | Description of the Classification                                   |
+| highlights           |      | highlight snippets   | Read-only [Highlight snippets](#highlights) per resource attribute  |
+| explicitPermissions  |      | explicit permissions | Write-only [Explicit permissions](#explicit-permissions)            |
+| effectivePermissions |      | string array         | Read-only [Effective permissions](#effective-permissions)           |
+| classification       |      | array of resources   | Related Tags                                                        |
+| sections             |      | array of resources   | Related Sections                                                    |
 
 ### Expand
 
@@ -125,22 +134,25 @@ A Classification accepts the following `expand` values:
 
 ### Data
 
+The Tag resource is identified by `tag` in URLs.
+
 A Tag is identified by the following attributes:
 
-| Attribute       | Sort | Data type          | Comment                                                             |
-|-----------------|------|--------------------|---------------------------------------------------------------------|
-| id              | X    | string             | (Globally) Unique identifier of the resource                        |
-| revision        | X    | integer            | Revision of the resource used for concurrent modification detection |
-| createdDate     | X    | timestamp          | Timestamp at which the resource was created                         |
-| createdBy       | X    | string             | User name of the user who created the resource                      |
-| createdByUserId | X    | string             | User ID of the user who created the resource                        |
-| updatedDate     | X    | timestamp          | Timestamp at which the resource was updated                         |
-| updatedBy       | X    | string             | User name of the user who last updated the resource                 |
-| updatedByUserId | X    | string             | User ID of the user who updated the resource                        |
-| title           | X    | string             | Title of the Tag                                                    |
-| description     | X    | string             | Description of the Tag                                              |
-| highlights      |      | highlight snippets | [Highlight snippets](#highlights) per resource attribute.           |
-| classification  |      | resource           | Parent Classification                                               |
+| Attribute            | Sort | Data type          | Comment                                                             |
+|----------------------|------|--------------------|---------------------------------------------------------------------|
+| id                   | X    | string             | (Globally) Unique identifier of the resource                        |
+| revision             | X    | integer            | Revision of the resource used for concurrent modification detection |
+| createdDate          | X    | timestamp          | Timestamp at which the resource was created                         |
+| createdBy            | X    | string             | User name of the user who created the resource                      |
+| createdByUserId      | X    | string             | User ID of the user who created the resource                        |
+| updatedDate          | X    | timestamp          | Timestamp at which the resource was updated                         |
+| updatedBy            | X    | string             | User name of the user who last updated the resource                 |
+| updatedByUserId      | X    | string             | User ID of the user who updated the resource                        |
+| title                | X    | string             | Title of the Tag                                                    |
+| description          | X    | string             | Description of the Tag                                              |
+| highlights           |      | highlight snippets | Read-only [Highlight snippets](#highlights) per resource attribute  |
+| effectivePermissions |      | string array       | Read-only [Effective permissions](#effective-permissions)           |
+| classification       |      | resource           | Parent Classification                                               |
 
 ### Expand
 
@@ -151,24 +163,28 @@ A Tag accepts the following `expand` values:
 
 ### Data
 
+The Section resource is identified by `section` in URLs.
+
 A Section is identified by the following attributes:
 
-| Attribute       | Sort | Data type          | Comment                                                             |
-|-----------------|------|--------------------|---------------------------------------------------------------------|
-| id              | X    | string             | (Globally) Unique identifier of the resource                        |
-| revision        | X    | integer            | Revision of the resource used for concurrent modification detection |
-| createdDate     | X    | timestamp          | Timestamp at which the resource was created                         |
-| createdBy       | X    | string             | User name of the user who created the resource                      |
-| createdByUserId | X    | string             | User ID of the user who created the resource                        |
-| updatedDate     | X    | timestamp          | Timestamp at which the resource was updated                         |
-| updatedBy       | X    | string             | User name of the user who last updated the resource                 |
-| updatedByUserId | X    | string             | User ID of the user who updated the resource                        |
-| title           | X    | string             | Title of the Tag                                                    |
-| description     | X    | string             | Description of the Section                                          |
-| highlights      |      | highlight snippets | [Highlight snippets](#highlights) per resource attribute.           |
-| classifications |      | array of resources | Related Classifications                                             |
-| entries         |      | array of resources | Related Entries                                                     |
-| externalIds     |      | array of resources | Related ExternalIds                                                 |
+| Attribute            | Sort | Data type            | Comment                                                             |
+|----------------------|------|----------------------|---------------------------------------------------------------------|
+| id                   | X    | string               | (Globally) Unique identifier of the resource                        |
+| revision             | X    | integer              | Revision of the resource used for concurrent modification detection |
+| createdDate          | X    | timestamp            | Timestamp at which the resource was created                         |
+| createdBy            | X    | string               | User name of the user who created the resource                      |
+| createdByUserId      | X    | string               | User ID of the user who created the resource                        |
+| updatedDate          | X    | timestamp            | Timestamp at which the resource was updated                         |
+| updatedBy            | X    | string               | User name of the user who last updated the resource                 |
+| updatedByUserId      | X    | string               | User ID of the user who updated the resource                        |
+| title                | X    | string               | Title of the Tag                                                    |
+| description          | X    | string               | Description of the Section                                          |
+| highlights           |      | highlight snippets   | Read-only [Highlight snippets](#highlights) per resource attribute  |
+| explicitPermissions  |      | explicit permissions | Write-only [Explicit permissions](#explicit-permissions)            |
+| effectivePermissions |      | string array         | Read-only [Effective permissions](#effective-permissions)           |
+| classifications      |      | array of resources   | Related Classifications                                             |
+| entries              |      | array of resources   | Related Entries                                                     |
+| externalIds          |      | array of resources   | Related ExternalIds                                                 |
 
 ### Expand
 
@@ -181,26 +197,29 @@ A Section accepts the following `expand` values:
 
 ### Data
 
+The Entry resource is identified by `entry` in URLs.
+
 An Entry is identified by the following attributes:
 
-| Attribute       | Sort | Data type          | Comment                                                             |
-|-----------------|------|--------------------|---------------------------------------------------------------------|
-| id              | X    | string             | (Globally) Unique identifier of the resource                        |
-| revision        | X    | integer            | Revision of the resource used for concurrent modification detection |
-| createdDate     | X    | timestamp          | Timestamp at which the resource was created                         |
-| createdBy       | X    | string             | User name of the user who created the resource                      |
-| createdByUserId | X    | string             | User ID of the user who created the resource                        |
-| updatedDate     | X    | timestamp          | Timestamp at which the resource was updated                         |
-| updatedBy       | X    | string             | User name of the user who last updated the resource                 |
-| updatedByUserId | X    | string             | User ID of the user who updated the resource                        |
-| title           | X    | string             | Title of the Entry                                                  |
-| description     | X    | string             | Description of the Entry                                            |
-| highlights      |      | highlight snippets | [Highlight snippets](#highlights) per resource attribute.           |
-| section         |      | resource           | Parent Section                                                      |
-| tags            |      | array of resources | Related Tags                                                        |
-| documents       |      | array of resources | Related Documents                                                   |
-| externalIds     |      | array of resources | Related ExternalIds                                                 |
-| parties         |      | array of resources | Related Parties                                                     |
+| Attribute            | Sort | Data type          | Comment                                                             |
+|----------------------|------|--------------------|---------------------------------------------------------------------|
+| id                   | X    | string             | (Globally) Unique identifier of the resource                        |
+| revision             | X    | integer            | Revision of the resource used for concurrent modification detection |
+| createdDate          | X    | timestamp          | Timestamp at which the resource was created                         |
+| createdBy            | X    | string             | User name of the user who created the resource                      |
+| createdByUserId      | X    | string             | User ID of the user who created the resource                        |
+| updatedDate          | X    | timestamp          | Timestamp at which the resource was updated                         |
+| updatedBy            | X    | string             | User name of the user who last updated the resource                 |
+| updatedByUserId      | X    | string             | User ID of the user who updated the resource                        |
+| title                | X    | string             | Title of the Entry                                                  |
+| description          | X    | string             | Description of the Entry                                            |
+| highlights           |      | highlight snippets | Read-only [Highlight snippets](#highlights) per resource attribute  |
+| effectivePermissions |      | string array       | Read-only [Effective permissions](#effective-permissions)           |
+| section              |      | resource           | Parent Section                                                      |
+| tags                 |      | array of resources | Related Tags                                                        |
+| documents            |      | array of resources | Related Documents                                                   |
+| externalIds          |      | array of resources | Related ExternalIds                                                 |
+| parties              |      | array of resources | Related Parties                                                     |
 
 ### Expand
 
@@ -216,30 +235,33 @@ An Entry accepts the following `expand` values:
 
 ### Data
 
+The Party resource is identified by `party` in URLs.
+
 A Party is identified by the following attributes:
 
-| Attribute          | Sort | Data type          | Comment                                                             |
-|--------------------|------|--------------------|---------------------------------------------------------------------|
-| id                 | X    | string             | (Globally) Unique identifier of the resource                        |
-| revision           | X    | integer            | Revision of the resource used for concurrent modification detection |
-| createdDate        | X    | timestamp          | Timestamp at which the resource was created                         |
-| createdBy          | X    | string             | User name of the user who created the resource                      |
-| createdByUserId    | X    | string             | User ID of the user who created the resource                        |
-| updatedDate        | X    | timestamp          | Timestamp at which the resource was updated                         |
-| updatedBy          | X    | string             | User name of the user who last updated the resource                 |
-| updatedByUserId    | X    | string             | User ID of the user who updated the resource                        |
-| name               | X    | string             | Name of the party                                                   |
-| personalNumber     | X    | string             | Personal number of the party                                        |
-| organizationNumber | X    | string             | Organization number of the party                                    |
-| tempPersonalNumber | X    | string             | Temporary personal number of the party                              |
-| mailingAddress     | X    | string             | Mailing address of the party                                        |
-| postalCode         | X    | string             | Postal code of the party                                            |
-| city               | X    | string             | City of the party                                                   |
-| country            | X    | string             | Country of the party                                                |
-| emailAddress       | X    | string             | E-mail address of the party                                         |
-| phoneNumber        | X    | string             | Phone number of the party                                           |
-| highlights         |      | highlight snippets | [Highlight snippets](#highlights) per resource attribute.           |
-| entry              |      | resource           | Parent Entry                                                        |
+| Attribute            | Sort | Data type          | Comment                                                             |
+|----------------------|------|--------------------|---------------------------------------------------------------------|
+| id                   | X    | string             | (Globally) Unique identifier of the resource                        |
+| revision             | X    | integer            | Revision of the resource used for concurrent modification detection |
+| createdDate          | X    | timestamp          | Timestamp at which the resource was created                         |
+| createdBy            | X    | string             | User name of the user who created the resource                      |
+| createdByUserId      | X    | string             | User ID of the user who created the resource                        |
+| updatedDate          | X    | timestamp          | Timestamp at which the resource was updated                         |
+| updatedBy            | X    | string             | User name of the user who last updated the resource                 |
+| updatedByUserId      | X    | string             | User ID of the user who updated the resource                        |
+| name                 | X    | string             | Name of the party                                                   |
+| personalNumber       | X    | string             | Personal number of the party                                        |
+| organizationNumber   | X    | string             | Organization number of the party                                    |
+| tempPersonalNumber   | X    | string             | Temporary personal number of the party                              |
+| mailingAddress       | X    | string             | Mailing address of the party                                        |
+| postalCode           | X    | string             | Postal code of the party                                            |
+| city                 | X    | string             | City of the party                                                   |
+| country              | X    | string             | Country of the party                                                |
+| emailAddress         | X    | string             | E-mail address of the party                                         |
+| phoneNumber          | X    | string             | Phone number of the party                                           |
+| highlights           |      | highlight snippets | Read-only [Highlight snippets](#highlights) per resource attribute  |
+| effectivePermissions |      | string array       | Read-only [Effective permissions](#effective-permissions)           |
+| entry                |      | resource           | Parent Entry                                                        |
 
 ### Expand
 
@@ -250,23 +272,26 @@ A Party accepts the following `expand` values:
 
 ### Data
 
+The Document resource is identified by `document` in URLs.
+
 A Document is identified by the following attributes:
 
-| Attribute        | Sort | Data type          | Comment                                                             |
-|------------------|------|--------------------|---------------------------------------------------------------------|
-| id               | X    | string             | (Globally) Unique identifier of the resource                        |
-| revision         | X    | integer            | Revision of the resource used for concurrent modification detection |
-| createdDate      | X    | timestamp          | Timestamp at which the resource was created                         |
-| createdBy        | X    | string             | User name of the user who created the resource                      |
-| createdByUserId  | X    | string             | User ID of the user who created the resource                        |
-| updatedDate      | X    | timestamp          | Timestamp at which the resource was updated                         |
-| updatedBy        | X    | string             | User name of the user who last updated the resource                 |
-| updatedByUserId  | X    | string             | User ID of the user who updated the resource                        |
-| title            | X    | string             | Title of the Document                                               |
-| highlights       |      | highlight snippets | [Highlight snippets](#highlights) per resource attribute.           |
-| entry            |      | resource           | Parent Entry                                                        |
-| externalIds      |      | resource           | Related ExternalIds                                                 |
-| documentVersions |      | resource           | Related Document Versions                                           |
+| Attribute            | Sort | Data type          | Comment                                                             |
+|----------------------|------|--------------------|---------------------------------------------------------------------|
+| id                   | X    | string             | (Globally) Unique identifier of the resource                        |
+| revision             | X    | integer            | Revision of the resource used for concurrent modification detection |
+| createdDate          | X    | timestamp          | Timestamp at which the resource was created                         |
+| createdBy            | X    | string             | User name of the user who created the resource                      |
+| createdByUserId      | X    | string             | User ID of the user who created the resource                        |
+| updatedDate          | X    | timestamp          | Timestamp at which the resource was updated                         |
+| updatedBy            | X    | string             | User name of the user who last updated the resource                 |
+| updatedByUserId      | X    | string             | User ID of the user who updated the resource                        |
+| title                | X    | string             | Title of the Document                                               |
+| highlights           |      | highlight snippets | Read-only [Highlight snippets](#highlights) per resource attribute  |
+| effectivePermissions |      | string array       | Read-only [Effective permissions](#effective-permissions)           |
+| entry                |      | resource           | Parent Entry                                                        |
+| externalIds          |      | resource           | Related ExternalIds                                                 |
+| documentVersions     |      | resource           | Related Document Versions                                           |
 
 ### Expand
 
@@ -279,28 +304,31 @@ A Document accepts the following `expand` values:
 
 ### Data
 
+The Document Version resource is identified by `document-version` in URLs.
+
 A DocumentVersion is identified by the following attributes:
 
-| Attribute          | Sort | Data type          | Comment                                                             |
-|--------------------|------|--------------------|---------------------------------------------------------------------|
-| id                 | X    | string             | (Globally) Unique identifier of the resource                        |
-| revision           | X    | integer            | Revision of the resource used for concurrent modification detection |
-| createdDate        | X    | timestamp          | Timestamp at which the resource was created                         |
-| createdBy          | X    | string             | User name of the user who created the resource                      |
-| createdByUserId    | X    | string             | User ID of the user who created the resource                        |
-| updatedDate        | X    | timestamp          | Timestamp at which the resource was updated                         |
-| updatedBy          | X    | string             | User name of the user who last updated the resource                 |
-| updatedByUserId    | X    | string             | User ID of the user who updated the resource                        |
-| fileName           |      | string             | File name of the document version                                   |
-| checksum           |      | string             | Checksum of the document version                                    |
-| checksumAlgorithm  |      | string             | Checksum algorithm of the document version                          |
-| fileSize           |      | integer            | File size of the document version                                   |
-| contentType        |      | string             | Content type of the document version                                |
-| versionNumber      | X    | integer            | Version number of the document version                              |
-| highlights         |      | highlight snippets | [Highlight snippets](#highlights) per resource attribute.           |
-| document           |      | resource           | Parent Document                                                     |
-| electronicDocument |      | resource           | Related ElectronicDocuemnt as uploaded by the upload endpoint       |
-| externalIds        |      | resource           | Related ExternalIds                                                 |
+| Attribute            | Sort | Data type          | Comment                                                             |
+|----------------------|------|--------------------|---------------------------------------------------------------------|
+| id                   | X    | string             | (Globally) Unique identifier of the resource                        |
+| revision             | X    | integer            | Revision of the resource used for concurrent modification detection |
+| createdDate          | X    | timestamp          | Timestamp at which the resource was created                         |
+| createdBy            | X    | string             | User name of the user who created the resource                      |
+| createdByUserId      | X    | string             | User ID of the user who created the resource                        |
+| updatedDate          | X    | timestamp          | Timestamp at which the resource was updated                         |
+| updatedBy            | X    | string             | User name of the user who last updated the resource                 |
+| updatedByUserId      | X    | string             | User ID of the user who updated the resource                        |
+| fileName             |      | string             | File name of the document version                                   |
+| checksum             |      | string             | Checksum of the document version                                    |
+| checksumAlgorithm    |      | string             | Checksum algorithm of the document version                          |
+| fileSize             |      | integer            | File size of the document version                                   |
+| contentType          |      | string             | Content type of the document version                                |
+| versionNumber        | X    | integer            | Version number of the document version                              |
+| highlights           |      | highlight snippets | Read-only [Highlight snippets](#highlights) per resource attribute  |
+| effectivePermissions |      | string array       | Read-only [Effective permissions](#effective-permissions)           |
+| document             |      | resource           | Parent Document                                                     |
+| electronicDocument   |      | resource           | Related ElectronicDocuemnt as uploaded by the upload endpoint       |
+| externalIds          |      | resource           | Related ExternalIds                                                 |
 
 ### Expand
 
@@ -312,23 +340,26 @@ A DocumentVersion accepts the following `expand` values:
 
 ### Data
 
+The External ID resource is identified by `external-id` in URLs.
+
 An ExternalID is identified by the following attributes:
 
-| Attribute       | Sort | Data type          | Comment                                                             |
-|-----------------|------|--------------------|---------------------------------------------------------------------|
-| id              | X    | string             | (Globally) Unique identifier of the resource                        |
-| revision        | X    | integer            | Revision of the resource used for concurrent modification detection |
-| createdDate     | X    | timestamp          | Timestamp at which the resource was created                         |
-| createdBy       | X    | string             | User name of the user who created the resource                      |
-| createdByUserId | X    | string             | User ID of the user who created the resource                        |
-| updatedDate     | X    | timestamp          | Timestamp at which the resource was updated                         |
-| updatedBy       | X    | string             | User name of the user who last updated the resource                 |
-| updatedByUserId | X    | string             | User ID of the user who updated the resource                        |
-| externalId      | X    | string             | External ID                                                         |
-| highlights      |      | highlight snippets | [Highlight snippets](#highlights) per resource attribute.           |
-| entry           |      | resource           | Parent Entry, if any                                                |
-| document        |      | resource           | Parent Document, if any                                             |
-| documentVersion |      | resource           | Parent Document Version, if any                                     |
+| Attribute            | Sort | Data type          | Comment                                                             |
+|----------------------|------|--------------------|---------------------------------------------------------------------|
+| id                   | X    | string             | (Globally) Unique identifier of the resource                        |
+| revision             | X    | integer            | Revision of the resource used for concurrent modification detection |
+| createdDate          | X    | timestamp          | Timestamp at which the resource was created                         |
+| createdBy            | X    | string             | User name of the user who created the resource                      |
+| createdByUserId      | X    | string             | User ID of the user who created the resource                        |
+| updatedDate          | X    | timestamp          | Timestamp at which the resource was updated                         |
+| updatedBy            | X    | string             | User name of the user who last updated the resource                 |
+| updatedByUserId      | X    | string             | User ID of the user who updated the resource                        |
+| externalId           | X    | string             | External ID                                                         |
+| highlights           |      | highlight snippets | Read-only [Highlight snippets](#highlights) per resource attribute  |
+| effectivePermissions |      | string array       | Read-only [Effective permissions](#effective-permissions)           |
+| entry                |      | resource           | Parent Entry, if any                                                |
+| document             |      | resource           | Parent Document, if any                                             |
+| documentVersion      |      | resource           | Parent Document Version, if any                                     |
 
 ### Expand
 
@@ -337,6 +368,25 @@ A DocumentVersion accepts the following `expand` values:
 - document
 - documentVersion
 - externalIds
+
+## Access Group
+
+### Data
+
+The Access Group resource is identified by `access-group` in URLs.
+
+An AccessGroup is identified by the following attributes:
+
+| Attribute          | Data type    | Comment                                                                               |
+|--------------------|--------------|---------------------------------------------------------------------------------------|
+| id                 | string       | (Globally) Unique identifier of the resource                                          |
+| name               | string       | Human-readable name of the access group                                               |
+| description        | string       | Description of the access group                                                       |
+| claim              | string       | External user claim upon which a user will be assigned as a member of an access group |
+| globalPermissions  | string array | [Global permissions](#explicit-permissions)                                           |
+| servicePermissions | string array | [Service permissions](#service-permissions)                                           |
+
+Note that `expand`, `attribute`, and `sort` cannot be used when looking up access groups.
 
 ## Model constraints
 
@@ -378,10 +428,205 @@ The following constraints apply to the `updated*` fields:
 }
 ```
 
-The following rules apply to highlights
+The following rules apply to highlights:
 
 * `attribute` may be the name of any `attribute` of the resource in which the `highlights` appear. For example `text`;
 * at most 10 highlight snippets will be returned per `attribute`;
 * the `|=hlstart=|` opening "tag" and `|=hlstop=|` closing "tag" identify a highlighted word (or sequence of words) in a highlight snippet;
 * each highlight snippet will contain one or more `|=hlstart=|` opening "tags" and `|=hlstop=|` closing "tags" depending in the search results;
 * `highlights` for an `attribute` will be returned (if any) even if the the `attribute` itself is excluded from the response by means of specifying the `attributes` request field. It is especially useful to exclude the `text` attribute of document versions in Search requests and only rely on the `highlights` considering that the a document may contain large amounts of context.
+
+Note that `highlights` cannot be requested via the `attributes` request field.
+
+## Effective permissions
+
+The effective permissions attribute is found on most of the resources. The values of that attribute determine what kind of permissions the current user has for the current resource. The `effectivePermissions` attribute will be returned in responses, but cannot be specified as part of create or update requests.
+
+`effectivePermissions` have the following format when returned as part of a resource:
+```json
+{
+    "effectivePermissions": [
+        "Update",
+        "Delete",
+        "ReadChildren",
+        "CreateChildren",
+        "UpdateSystemFields",
+        "ModifyPermissions"
+    ]
+}
+```
+
+The following `effectivePermissions` may be returned per resource:
+
+- `Update`
+  - indicates that the user has permissions to update the regular attributes of the current resource such as `title`, `description`, etc. See `UpdateSystemFields` for more information
+  - indicates that the user has permissions to link related resources to the current resource as part of move or create operations such as:
+    - linking classifications to sections
+    - linking tags to entries
+    - creating or moving entries in/between sections
+    - creating or moving document versions in/between documents
+    - etc.
+- `Delete`
+  - indicates that the user has permissions to delete the current resource and its children
+- `ReadChildren`
+  - indicates that the user has permissions to retrieve children of the current resource and their children
+- `CreateChildren`
+  - indicates that the user has permissions to create children in the current resource such as:
+    - entries in sections
+    - tags in classifications
+    - parties in entries
+    - document in entries
+    - etc.
+  - note that to create a child resource in a parent resource, the user must also have the `Update` effective permission on the parent resource
+- `UpdateSystemFields`
+  - indicates that the user has permissions to update the system attributes of the current resource or the system attributes of any of its children such as `created*` and `updated*` attributes
+- `ModifyPermissions`
+  - indicates that the user has permissions to update the [Explicit permissions](#explicit-permissions) of a resource or any of its children
+
+Note that new effective permissions may be added in the future.
+
+Note that `effectivePermissions` cannot be requested via the `attributes` request field.
+
+## Explicit permissions
+
+Explicit permissions are found on `Classification` and `Section` in the form of the `explicitPermissions` attribute and on `AccessGroup` in the form of the `globalPermissions` attribute. The values of that attribute determine the permissions assigned to a resource based on which [Effective permissions](#effective-permissions) are then calculated.
+
+For Sections and Classifications the `explicitPermission` attribute can be specified in create and update requests, but will not be returned in responses.
+
+For AccessGroups, the `globalPermissions` attribute can be specified in create and update requests and will be returned in responses, if not empty.
+
+`explicitPermission`/`globalPermissions` accept the following format when used in create and update requests :
+```json
+{
+    "explicitPermission": {
+        "group identifier 1": [
+            "ReadObject",
+            "ReadChildren",
+            "CreateChildren",
+            "UpdateChildren",
+            "DeleteChildren",
+            "ModifyChildrenPermissions",
+            "UpdateChildrenSystemFields"
+        ],
+        "group identifier 2": [
+            ...
+        ],
+        ...
+    }
+}
+```
+
+The following `explicitPermissions`/`globalPermissions` can be specified for `Classification`, `Section`, and `AccessGroup`:
+
+- `ReadObject`
+  - grants permissions to members of the specified access group to read the current resource
+  - the permission is granted automatically to every newly-created access group
+- `ReadChildren`
+  - grants permissions to members of the specified access group to read the children of the current resource (and the children of their children, etc.)
+  - used together, `ReadObject` and `ReadChildren` grant access to the user of the specified group access to all Classifications and their Tags or to all Sections and their children (Entries, Documents, etc.) for example
+- `CreateChildren`
+  - grants permissions to members of the specified access group to create children of the current resource
+- `UpdateChildren`
+  - grants permissions to members of the specified access group to update regular attributes of the children of the current resource such as `title`, `description`, etc.
+- `DeleteChildren`
+  - grants permissions to members of the specified access group to delete children of the current resource
+- `ModifyChildrenPermissions`
+  - grants permissions to members of the specified access group to modify the permissions assigned to children of the current resource
+  - not currently in use
+- `UpdateChildrenSystemFields`
+  - grants permissions to members of the specified access group to update system attributes of the children of the current resource such as `created*` and `updated*` attributes
+
+Note that new explicit permissions may be added in the future.
+
+### Explicit permissions use cases
+
+#### Users with global read access to the system
+
+To grant users access to read everything in the archive create or update their access group with the following explicit/global permissions:
+
+- `ReadObject`
+- `ReadChildren`
+
+#### Global administrators of the system
+
+To grant users access to read and edit everything in the archive create or update their access group with the following explicit/global permissions:
+
+- `ReadObject`
+- `ReadChildren`
+- `CreateChildren`
+- `UpdateChildren`
+- `UpdateChildrenSystemFields`
+
+You could optionally grant `DeleteChildren`, but Documaster recommends that only a small number of people have rights to delete data in the archive.
+
+#### Global administrators of the system with rights to grant or revoke permissions to resources
+
+To grant users access to read and edit everything in the archive, including permissions on resources, create or update their access group with the following explicit/global permissions:
+
+- `ReadObject`
+- `ReadChildren`
+- `CreateChildren`
+- `UpdateChildren`
+- `UpdateChildrenSystemFields`
+- `ModifyChildrenPermissions`
+
+You could optionally grant `DeleteChildren`, but Documaster recommends that only a small number of people have rights to delete data in the archive.
+
+#### Users with access only to a particular Section in the archive
+
+To grant users access to read and edit everything only in a single Section in the archive, create or update their access group with the following explicit/global permissions:
+
+- `ReadObject`
+
+Additionally, update the Section you would like to grant them access to like so:
+
+```json
+{
+    "explicitPermissions": {
+        "user access group ID": [
+            "ReadObject", "ReadChildren", "CreateChildren", "UpdateChildren", "UpdateChildrenSystemFields"
+        ]
+    }
+}
+```
+
+You could optionally grant `DeleteChildren` on the Sections, but Documaster recommends that only a small number of people have rights to delete data in the archive.
+
+Finally, update all Classifications linked to the aforementioned Section like so:
+
+```json
+{
+    "explicitPermissions": {
+        "user access group ID": [
+            "ReadObject", "ReadChildren"
+        ]
+    }
+}
+```
+
+You could optionally grant `CreateChildren` and `UpdateChildren` on the Classifications if you would like them to be able to create or edit existing Tags.
+
+You could optionally grant `DeleteChildren` on the Classifications, but Documaster recommends that only a small number of people have rights to delete data in the archive.
+
+## Service permissions
+
+The service permissions attribute is found only on `AccessGroup`. The values of that attribute determine the types of actions members of an access group can perform in Documaster. The `servicePermissions` attribute can be specified in create and update requests and will be returned in responses.
+
+`servicePermissions` accept the following format when used in create and update requests :
+```json
+{
+    "servicePermissions": [
+        "UploadDocuments",
+        "ManageAccessGroups"
+    ]
+}
+```
+
+The following `servicePermissions` can be specified for `AccessGroup`:
+
+- `UploadDocuments`
+  - grants permissions to members of the specified access group to upload documents in the system
+- `ManageAccessGroups`
+  - grants permissions to members of the specified access group to manage the access groups in the system (create, update, and delete)
+
+Note that new service permissions may be added in the future.


### PR DESCRIPTION
Changes in the API documentation:

* Support for access-group endpoints
* Support for explicit permissions on Classification and Section
* Support for read-only effective permissions on all resources
* Support for service permissions